### PR TITLE
pomo-203-run-lint-action-for-all-code-files

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "extends": [
+    "react-app",
+    "react-app/jest",
+    "airbnb"
+  ],
+  "overrides": [
+    {
+      "files": [
+        "**/*.js?(x)"
+      ]
+    }
+  ]
+}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,3 +26,4 @@ jobs:
         uses: wearerequired/lint-action@v1
         with:
           eslint: true
+          eslint_extensions: js,jsx

--- a/package.json
+++ b/package.json
@@ -19,20 +19,6 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject"
   },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest",
-      "airbnb"
-    ],
-    "overrides": [
-      {
-        "files": [
-          "**/*.js?(x)"
-        ]
-      }
-    ]
-  },
   "browserslist": {
     "production": [
       ">0.2%",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,13 @@
       "react-app",
       "react-app/jest",
       "airbnb"
+    ],
+    "overrides": [
+      {
+        "files": [
+          "**/*.js?(x)"
+        ]
+      }
     ]
   },
   "browserslist": {


### PR DESCRIPTION
[Asana Task](https://app.asana.com/0/0/1200407379247671/f)

Running `eslint .`, which is the command that Lint Action uses, used to
only run on `*.js` files. However, this is not enough because we need to
run ESLint on `*.jsx` files as well because we use this extension for
React component files.